### PR TITLE
OS Command Injection

### DIFF
--- a/typescript/vulnerableCommandExecution.ts
+++ b/typescript/vulnerableCommandExecution.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import express from 'express';
 
 const app = express();
@@ -7,9 +7,14 @@ app.use(express.json());
 
 app.post('/run-command', (req, res) => {
     const userCommand = req.body.command;  // User input from the request body
-
-    // Vulnerability: Directly using user input in a command executed by the system
-    exec(userCommand, (error, stdout, stderr) => {
+    const allowedCommands = ['ls', 'whoami']; // Whitelist of allowed commands
+    
+    if (!allowedCommands.includes(userCommand)) {
+        res.status(400).send('Command not allowed.');
+        return;
+    }
+    
+    execFile(userCommand, (error, stdout, stderr) => {
         if (error) {
             res.status(500).send(`Error executing command: ${error.message}`);
             return;
@@ -18,7 +23,7 @@ app.post('/run-command', (req, res) => {
             res.status(500).send(`Command stderr: ${stderr}`);
             return;
         }
-
+        
         res.send(`Command output: ${stdout}`);
     });
 });


### PR DESCRIPTION
The code was fixed by implementing two key changes to address the OS command injection vulnerability:

1. **Use of `execFile` instead of `exec`:**
   - The original code used `exec`, which executes a command in a shell, allowing for shell-specific syntax and potentially dangerous command injection if user input is not properly sanitized. The corrected code uses `execFile`, which executes a file directly without invoking a shell. This reduces the risk of command injection because it does not interpret shell metacharacters, making it safer for executing commands with user input.

2. **Command Whitelisting:**
   - The corrected code introduces a whitelist of allowed commands (`allowedCommands` array) that the application can execute. Before executing a command, the code checks if the user-supplied command is in the whitelist. If the command is not allowed, the application responds with a 400 status code and an error message, preventing unauthorized or potentially harmful commands from being executed.

These changes ensure that only predefined, safe commands can be executed, significantly reducing the risk of arbitrary command execution and enhancing the security of the application.

Created by: info@plexicus.com